### PR TITLE
Fix parquet problems (and one with legacy pickle)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: nox
+        name: Nox
+        entry: nox -rs lint --
+        language: system
+        types: [python]
+        require_serial: true

--- a/src/klinker/data/blocks.py
+++ b/src/klinker/data/blocks.py
@@ -538,7 +538,6 @@ class KlinkerBlockManager:
             schema["__null_dask_index__"] = pa.int64()
             self.blocks.to_parquet(path, schema=schema, **kwargs)
 
-
     @classmethod
     def read_parquet(
         cls,

--- a/src/klinker/data/blocks.py
+++ b/src/klinker/data/blocks.py
@@ -532,6 +532,9 @@ class KlinkerBlockManager:
         try:
             self.blocks.to_parquet(path, schema=schema, **kwargs)
         except ValueError:
+            # If index is incorrectly assumed by dask to be string
+            # and it turns out to be int64 an error would be thrown
+            # This is kind of a dirty hack
             schema["__null_dask_index__"] = pa.int64()
             self.blocks.to_parquet(path, schema=schema, **kwargs)
 


### PR DESCRIPTION
Currently index info can get lost after writing to parquet. This PR only supplies schema info for left/right data columns and lets the index be automatically determined. If index is incorrectly assumed by dask to be `"O"` and it turns out to be `int64` an error would be thrown, which is caught by setting `schema["__null_dask_index__"] = pa.int64()`.
